### PR TITLE
Update incorrect filename link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://github.com/lgrammel/storyteller/assets/205036/963df672-a4fc-4d0f-a74c-1e
 
 ![full](https://github.com/lgrammel/storyteller/assets/205036/c11ec999-0fae-4d69-8610-34932e75555f)
 
-The main flow from the diagram can be found in [generateStoryFlow](https://github.com/lgrammel/storyteller/blob/main/src/storyteller/generateStoryFlow.ts). Most of the UI is implemented in [index.tsx](https://github.com/lgrammel/storyteller/blob/main/pages/index.tsx).
+The main flow from the diagram can be found in [generateStoryFlow](https://github.com/lgrammel/storyteller/blob/main/src/storyteller/storyTellerFlow.ts). Most of the UI is implemented in [index.tsx](https://github.com/lgrammel/storyteller/blob/main/pages/index.tsx).
 
 ## Development
 


### PR DESCRIPTION
`generateStoryFlow.ts` was renamed to `storyTellerFlow.ts` but  README didn't reflect the change, giving a 404 when clicking on the link.

Hope it helps! 🙂 Great project btw (just came across today)